### PR TITLE
proto: Client complains about stub compressors

### DIFF
--- a/openvpn/ssl/proto.hpp
+++ b/openvpn/ssl/proto.hpp
@@ -624,7 +624,12 @@ namespace openvpn {
 		      // server pushes compression but client has compression disabled
 		      // degrade to asymmetric compression (downlink only)
 		      comp_ctx = CompressContext(meth, true);
-		      OPENVPN_LOG("Server has pushed compressor " << comp_ctx.str() << ", but client has disabled compression, switching to asymmetric");
+		      if (!comp_ctx.is_any_stub(meth))
+		        {
+			  OPENVPN_LOG("Server has pushed compressor "
+				      << comp_ctx.str()
+			              << ", but client has disabled compression, switching to asymmetric");
+		        }
 		    }
 		}
 	    }


### PR DESCRIPTION
When connecting to a server which pushes a stub compressor and the
client has compression disabled, it will complain about it in the log.

  > Server has pushed compressor COMP_STUBv2, but client has disabled
    compression, switching to asymmetric

This is confusing, since stub compressors does not compress.  No need to
confuse the users, so we just remove the warning in this case.

Signed-off-by: David Sommerseth <davids@openvpn.net>