### PR TITLE
CryptoAlgs: Don't report any digests for ciphers not using them

### DIFF
--- a/openvpn/crypto/cryptoalgs.hpp
+++ b/openvpn/crypto/cryptoalgs.hpp
@@ -80,6 +80,7 @@ namespace openvpn {
       F_CIPHER=(1<<2),    // alg is a cipher
       F_DIGEST=(1<<3),    // alg is a digest
       F_ALLOW_DC=(1<<4),  // alg may be used in OpenVPN data channel
+      F_NO_CIPHER_DIGEST=(1<<5), // cipher alg does not depend on any additional digest
     };
 
     // size in bytes of AEAD "nonce tail" normally taken from
@@ -130,9 +131,9 @@ namespace openvpn {
       { "DES-EDE3-CBC", F_CIPHER|F_ALLOW_DC|CBC_HMAC,          24,  8,  8 },
       { "BF-CBC",       F_CIPHER|F_ALLOW_DC|CBC_HMAC,          16,  8,  8 },
       { "AES-256-CTR",  F_CIPHER,                              32, 16, 16 },
-      { "AES-128-GCM",  F_CIPHER|F_ALLOW_DC|AEAD,              16, 12, 16 },
-      { "AES-192-GCM",  F_CIPHER|F_ALLOW_DC|AEAD,              24, 12, 16 },
-      { "AES-256-GCM",  F_CIPHER|F_ALLOW_DC|AEAD,              32, 12, 16 },
+      { "AES-128-GCM",  F_CIPHER|F_ALLOW_DC|AEAD|F_NO_CIPHER_DIGEST,  16, 12, 16 },
+      { "AES-192-GCM",  F_CIPHER|F_ALLOW_DC|AEAD|F_NO_CIPHER_DIGEST,  24, 12, 16 },
+      { "AES-256-GCM",  F_CIPHER|F_ALLOW_DC|AEAD|F_NO_CIPHER_DIGEST,  32, 12, 16 },
       { "MD4",          F_DIGEST,                              16,  0,  0 },
       { "MD5",          F_DIGEST|F_ALLOW_DC,                   16,  0,  0 },
       { "SHA1",         F_DIGEST|F_ALLOW_DC,                   20,  0,  0 },
@@ -240,6 +241,20 @@ namespace openvpn {
       return type;
     }
 
+    /**
+     *  Check if a specific algorithm depends on an additional digest or not
+     *
+     * @param type CryptoAlgs::Type to check
+     *
+     * @return Returns true if the queried algorithm depends on a digest,
+     * 	       otherwise false.  The check is done strictly against the
+     * 	       CryptoAlgs::AlgFlags F_NO_CIPHER_DIGEST flag.
+     */
+    inline bool use_cipher_digest(const Type type)
+    {
+      const Alg& alg = get(type);
+      return !(alg.flags() & F_NO_CIPHER_DIGEST);
+    }
   }
 }
 

--- a/openvpn/crypto/cryptodc.hpp
+++ b/openvpn/crypto/cryptodc.hpp
@@ -184,7 +184,19 @@ namespace openvpn {
     }
 
     CryptoAlgs::Type cipher() const { return cipher_; }
-    CryptoAlgs::Type digest() const { return digest_; }
+
+    /**
+     *  Retrieve the digest configured for the data channel.
+     *  If the configured data channel cipher does not use any
+     *  additional digest, CryptoAlgs::NONE is returned.
+     *
+     * @return  Returns the cipher digest in use
+     */
+    CryptoAlgs::Type digest() const
+    {
+      return (CryptoAlgs::use_cipher_digest(cipher_) ? digest_ : CryptoAlgs::NONE);
+    }
+
 
     CryptoDCFactory::Ptr factory() const { return factory_; }
 


### PR DESCRIPTION
The CryptoDCSettings::digest() method returns SHA1 digest when the
cipher is an AEAD cipher.  This is incorrect, as AEAD ciphers does not
use digests for authentication at all; the authentication is an
integral part of the AEAD cipher itself.

To solve this, the CryptoAlgs::AlgFlags has been extended with a new
F_NO_CIPHER_DIGEST flag which is expected to be set on ciphers not
depending on any digests for authentication, like AES-GCM/AEAD
ciphers.  A new method, use_cipher_digest(), will return True if
the cipher depends on a digest for authentication.

Signed-off-by: David Sommerseth <davids@openvpn.net>