### PR TITLE
Implement tls-groups option to specify eliptic curves/groups

### DIFF
--- a/openvpn/openssl/compat.hpp
+++ b/openvpn/openssl/compat.hpp
@@ -366,4 +366,9 @@ inline const BIGNUM *DSA_get0_p(const DSA *d)
     DSA_get0_pqg(d, &p, nullptr, nullptr);
     return p;
 }
+
+inline int SSL_CTX_set1_groups(SSL_CTX *ctx, int *glist, int glistlen)
+{
+    return SSL_CTX_set1_curves(ctx, glist, glistlen);
+}
 #endif


### PR DESCRIPTION
OpenSSL 1.1+ by default only allows signatures and key exchange from the
default list of X25519:secp256r1:X448:secp521r1:secp384r1. Since in
TLS1.3 key exchange is independent from the signature/key of the
certificates, allowing all groups per default is not a sensible choice
anymore and the shorter lister is reasonable.

However, when using certificates with exotic curves the signatures of
this certificates will no longer be accepted. This option allows to
modify the list for these corner cases.

Signed-off-by: Arne Schwabe <arne@openvpn.net>