### PR TITLE
awsca.hpp: use proper CA path

### DIFF
--- a/openvpn/aws/awsca.hpp
+++ b/openvpn/aws/awsca.hpp
@@ -29,7 +29,21 @@ namespace openvpn {
   namespace AWS {
     inline std::string api_ca()
     {
-      return read_text_unix("/etc/ssl/certs/ca-certificates.crt");
+      // paths are copied from https://golang.org/src/crypto/x509/root_linux.go
+      std::list<std::string> certs = {
+	"/etc/ssl/certs/ca-certificates.crt", // debian/ubuntu
+	"/etc/pki/tls/certs/ca-bundle.crt", // fedora/rhel6
+	"/etc/ssl/ca-bundle.pem", // opensuse,
+	"/etc/pki/tls/cacert.pem" // openelec
+	"/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem" // centos/rhel7
+	"/etc/ssl/cert.pem" // alpine
+      };
+      for (const auto& cert : certs)
+        {
+	  if (std::ifstream{cert})
+	    return read_text_unix(cert);
+        }
+      throw file_unix_error("No CA certificate files found in system paths");
     }
   }
 }


### PR DESCRIPTION
Different distros store CA certs in different places.

Try paths one by one until CA is found and
throw exception if not.

This is required to make AWS Addon for Linux client
work on non-Debian based distros.

Signed-off-by: Lev Stipakov <lev@openvpn.net>