### PR TITLE
win/tunsetup: fix build error caused by merge conflict

### DIFF
--- a/openvpn/tun/win/client/tunsetup.hpp
+++ b/openvpn/tun/win/client/tunsetup.hpp
@@ -146,8 +146,8 @@ namespace openvpn {
 	if (ring_buffer)
 	  register_rings(th(), ring_buffer);
 
-	if (!wintun && tap.index_defined())
-	  Util::flush_arp(tap.index, os);
+	if (tun_type_ == Type::TapWindows6 && tap_.index_defined())
+	  Util::flush_arp(tap_.index, os);
 
 	return th.release();
       }


### PR DESCRIPTION
We've merged two commits (038c91e and dbd05f2) which are fine
separately but when merged together one has to be rebased on
top of another.

Signed-off-by: Lev Stipakov <lev@openvpn.net>