### PR TITLE
Add missing OpenSSL includes in openssl/compat.hpp

### DIFF
--- a/openvpn/openssl/compat.hpp
+++ b/openvpn/openssl/compat.hpp
@@ -30,6 +30,8 @@
 #include <openssl/dsa.h>
 #include <openssl/hmac.h>
 #include <openssl/err.h>
+#include <openssl/ec.h>
+#include <openssl/ssl.h>
 
 // make sure type 94 doesn't collide with anything in bio.h
 // Start with the same number as before


### PR DESCRIPTION
Add missing includes that allow the file to be included without having to
include them before including compat.hpp

Signed-off-by: Arne Schwabe <arne@openvpn.net>