### PR TITLE
Fix logic of INFO_PRE and INFO substring replacment swapped

### DIFF
--- a/openvpn/client/cliproto.hpp
+++ b/openvpn/client/cliproto.hpp
@@ -787,9 +787,9 @@ class Session : ProtoContext,
         // requires the VPN tunnel to be ready.
         ClientEvent::Base::Ptr ev;
         if (info_pre)
-            ev = new ClientEvent::Info(msg.substr(std::strlen("INFO,")));
-        else
             ev = new ClientEvent::Info(msg.substr(std::strlen("INFO_PRE,")));
+        else
+            ev = new ClientEvent::Info(msg.substr(std::strlen("INFO,")));
 
         // INFO_PRE is like INFO but it is never buffered
         if (info_hold && !info_pre)

--- a/test/ovpncli/cli.cpp
+++ b/test/ovpncli/cli.cpp
@@ -330,6 +330,10 @@ class Client : public ClientBase
                 std::getline(std::cin, cr_response);
                 post_cc_msg("CR_RESPONSE," + base64->encode(cr_response));
             }
+            else
+            {
+                std::cout << "Unrecognized INFO/INFO_PRE message: " << ev.info << std::endl;
+            }
         }
     }
 
@@ -344,6 +348,7 @@ class Client : public ClientBase
                 return;
             }
 #ifdef OPENVPN_PLATFORM_MAC
+            std::cout << "Trying to launch " << url_str << std::endl;
             std::thread thr([url_str]()
                             {
 			    CFURLRef url = CFURLCreateWithBytes(


### PR DESCRIPTION
The refactoring introduced a logic error were the two options are swapped.