### PR TITLE
GHA: copy caching enhancements for coverity scan from OpenVPN 2

### DIFF
--- a/.github/workflows/coverity-scan.yml
+++ b/.github/workflows/coverity-scan.yml
@@ -8,27 +8,41 @@ jobs:
   latest:
     runs-on: ubuntu-latest
     steps:
+      - name: Check submission cache
+        id: check_submit
+        uses: actions/cache/restore@v3
+        with:
+          path: |
+            cov-int
+          key: check-submit-${{ github.sha }}
+
       - name: Install dependencies
+        if: steps.check_submit.outputs.cache-hit != 'true'
         run: sudo apt update && sudo apt install -y libcap-dev libjsoncpp-dev liblzo2-dev liblz4-dev libssl-dev swig
       - name: Checkout OpenVPN 3
+        if: steps.check_submit.outputs.cache-hit != 'true'
         uses: actions/checkout@v3
         with:
           path: openvpn3
       - name: Checkout asio
+        if: steps.check_submit.outputs.cache-hit != 'true'
         uses: actions/checkout@v3
         with:
           repository: chriskohlhoff/asio
           path: asio
           ref: asio-1-28-0
       - name: Checkout xxHash
+        if: steps.check_submit.outputs.cache-hit != 'true'
         uses: actions/checkout@v3
         with:
           repository: Cyan4973/xxHash
           path: xxHash
           ref: v0.8.2
       - uses: lukka/get-cmake@latest
+        if: steps.check_submit.outputs.cache-hit != 'true'
 
       - name: Download Coverity Build Tool
+        if: steps.check_submit.outputs.cache-hit != 'true'
         run: |
           wget -q https://scan.coverity.com/download/cxx/linux64 --post-data "token=$TOKEN&project=OpenVPN%2Fopenvpn3" -O cov-analysis-linux64.tar.gz
           mkdir cov-analysis-linux64
@@ -37,13 +51,16 @@ jobs:
           TOKEN: ${{ secrets.COVERITY_SCAN_TOKEN }}
 
       - name: CMake configure
+        if: steps.check_submit.outputs.cache-hit != 'true'
         run: cmake -S openvpn3 -B cmake -DDEP_DIR=$PWD -GNinja
       - name: Build with cov-build
+        if: steps.check_submit.outputs.cache-hit != 'true'
         run: |
           PATH=`pwd`/cov-analysis-linux64/bin:$PATH
           cov-build --dir cov-int cmake --build cmake
 
       - name: Submit the result to Coverity Scan
+        if: steps.check_submit.outputs.cache-hit != 'true'
         run: |
           tar czvf openvpn.tgz cov-int
           curl --form token=$TOKEN \
@@ -55,3 +72,11 @@ jobs:
         env:
           TOKEN: ${{ secrets.COVERITY_SCAN_TOKEN }}
           EMAIL: ${{ secrets.COVERITY_SCAN_EMAIL }}
+
+      - name: Cache submission
+        if: steps.check_submit.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v3
+        with:
+          path: |
+            cov-int
+          key: ${{ steps.check_submit.outputs.cache-primary-key }}


### PR DESCRIPTION
Do not run the daily scan if there was no push since the last run.

Reduces resource usage and notification noise.