### PR TITLE
Fix fail silently bug in pre-commit hook

### DIFF
--- a/scripts/git-pre-commit-clangformat.sh
+++ b/scripts/git-pre-commit-clangformat.sh
@@ -76,7 +76,7 @@ else
     against=4b825dc642cb6eb9a060e54bf8d69288fbee4904
 fi
 
-CLANGFORMAT=$(command -v clang-format)
+CLANGFORMAT=$(command -v clang-format || true)
 
 # make sure the executable are correctly set
 if [ -z "$CLANGFORMAT" ] ; then


### PR DESCRIPTION
Without the change and in the absence of a clang-format command in the user's PATH, the script will fail in line 79 of the hook due to set -e.  It will fail to produce the error message starting at line 83.

The change allows the error message to print.