### PR TITLE
addr/macaddr: Refactor to modern C++

### DIFF
--- a/openvpn/addr/macaddr.hpp
+++ b/openvpn/addr/macaddr.hpp
@@ -22,11 +22,9 @@
 #ifndef OPENVPN_ADDR_MACADDR_H
 #define OPENVPN_ADDR_MACADDR_H
 
-#include <ostream>
-#include <cstring>
 #include <string>
+#include <array>
 
-#include <openvpn/common/exception.hpp>
 #include <openvpn/common/ostream.hpp>
 #include <openvpn/common/hexstr.hpp>
 
@@ -37,10 +35,7 @@ namespace openvpn {
 class MACAddr
 {
   public:
-    MACAddr()
-    {
-        std::memset(addr_, 0, sizeof(addr_));
-    }
+    MACAddr() = default;
 
     MACAddr(const unsigned char *addr)
     {
@@ -49,16 +44,16 @@ class MACAddr
 
     void reset(const unsigned char *addr)
     {
-        std::memcpy(addr_, addr, sizeof(addr_));
+        std::copy_n(addr, addr_.size(), addr_.begin());
     }
 
     std::string to_string() const
     {
-        return render_hex_sep(addr_, sizeof(addr_), ':');
+        return render_hex_sep(addr_.data(), addr_.size(), ':');
     }
 
   private:
-    unsigned char addr_[6];
+    std::array<unsigned char, 6> addr_{};
 };
 
 OPENVPN_OSTREAM(MACAddr, to_string)


### PR DESCRIPTION
Remove unused include directives.
Change internal member C-style array to std::arry for better safety. Adjust methods to use std::array.
Default constructor.
Use std::copy_n algorithm to clearly express intention.