### PR TITLE
pre-commit: Update clang-format to 18.1.8

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/pre-commit/mirrors-clang-format
-    rev: 'v18.1.3'
+    rev: 'v18.1.8'
     hooks:
       - id: clang-format
         files: \.[ch]pp$

--- a/openvpn/buffer/buffer.hpp
+++ b/openvpn/buffer/buffer.hpp
@@ -832,7 +832,7 @@ class BufferType : public ConstBufferType<T>
      * @param filled A boolean flag indicating if the buffer is filled.
      */
     BufferType(void *data, const size_t size, const bool filled)
-        : ConstBufferType<T>(data, size, filled){};
+        : ConstBufferType<T>(data, size, filled) {};
 
     /**
      * @brief Constructor for BufferType that takes a T pointer, size, and a flag indicating if the buffer is filled.
@@ -841,7 +841,7 @@ class BufferType : public ConstBufferType<T>
      * @param filled A boolean flag indicating if the buffer is filled.
      */
     BufferType(T *data, const size_t size, const bool filled)
-        : ConstBufferType<T>(data, size, filled){};
+        : ConstBufferType<T>(data, size, filled) {};
 
     /**
      * @brief Protected constructor for BufferType that takes a T pointer, offset, size, and capacity.
@@ -852,7 +852,7 @@ class BufferType : public ConstBufferType<T>
      */
   protected:
     BufferType(T *data, const size_t offset, const size_t size, const size_t capacity)
-        : ConstBufferType<T>(data, offset, size, capacity){};
+        : ConstBufferType<T>(data, offset, size, capacity) {};
 };
 
 //  ===============================================================================================

--- a/openvpn/client/acc_certcheck.hpp
+++ b/openvpn/client/acc_certcheck.hpp
@@ -42,7 +42,7 @@ struct SslApiBuilder
     SslApiBuilder(SSLLib::SSLAPI::Config::Ptr cfg)
         : mConfig(std::move(cfg)),
           mFactory(mConfig->new_factory()),
-          mServer(mFactory->ssl()){};
+          mServer(mFactory->ssl()) {};
 
     SslApiBuilder(const SslApiBuilder &) = delete;
     SslApiBuilder(SslApiBuilder &&) noexcept = delete;

--- a/openvpn/common/rc.hpp
+++ b/openvpn/common/rc.hpp
@@ -669,7 +669,7 @@ class thread_unsafe_refcount
   initializes rc to 0 for a new object with no references.
 */
 inline thread_unsafe_refcount::thread_unsafe_refcount() noexcept
-    : rc(olong(0)){};
+    : rc(olong(0)) {};
 /**
   @brief Increment ref count by 1
 */
@@ -1109,7 +1109,7 @@ class RCWeak
     typedef RCWeakPtr<RCWeak> WPtr;
 
     RCWeak() noexcept
-        : refcount_(this){};
+        : refcount_(this) {};
 
     virtual ~RCWeak() = default;
     RCWeak(const RCWeak &) = delete;


### PR DESCRIPTION
Since 18.1.3 as shipped with Ubuntu 24.04 seems to have bugs, this requires some code formatting changes.