### PR TITLE
ovpn-doxygen.cmake: Switch from WARN_AS_ERROR to WARN_LOGFILE

### DIFF
--- a/cmake/ovpn-doxygen.cmake
+++ b/cmake/ovpn-doxygen.cmake
@@ -28,7 +28,7 @@ function(configure_doxygen projname tgtname outputdir)
     set(DOXYGEN_DOT_MULTI_TARGETS YES)
     set(DOXYGEN_DOT_IMAGE_FORMAT svg)
     set(DOXYGEN_INTERACTIVE_SVG YES)
-    set(DOXYGEN_WARN_AS_ERROR YES)
+    set(DOXYGEN_WARN_LOGFILE "${CMAKE_CURRENT_BINARY_DIR}/doxygen-${tgtname}.warnings.log")
 
     doxygen_add_docs("doxygen-${tgtname}" ALL
         "${CMAKE_CURRENT_SOURCE_DIR}" ${OVPN_DOXYGEN_SOURCES}


### PR DESCRIPTION
Makes it easy to check for problems without
- hard-failing the doxygen build
- needing to grep for the error in the actual Doxygen output