### PR TITLE
Add convenience function that tests client support for pushed dns

### DIFF
--- a/openvpn/ssl/proto.hpp
+++ b/openvpn/ssl/proto.hpp
@@ -3602,6 +3602,12 @@ class ProtoContext : public logging::LoggingMixin<OPENVPN_DEBUG_PROTO,
             return proto_field_ & iv_proto_flag::IV_PROTO_DYN_TLS_CRYPT;
         }
 
+        //! Checks if the client can handle `dns` (as opposed to `dhcp-option`).
+        bool client_supports_dns_option() const
+        {
+            return proto_field_ & iv_proto_flag::IV_PROTO_DNS_OPTION_V2;
+        }
+
       private:
         unsigned int proto_field_;
     };


### PR DESCRIPTION
Newer clients can handle the dns option (as opposed to dhcp-option) so add a convenience function to test client support, which would allow servers to conditionally enable pushing dns instead of dhcp-options.