### PR TITLE
Hash64: replace is_pod with is_standard_layout

### DIFF
--- a/openvpn/common/hash.hpp
+++ b/openvpn/common/hash.hpp
@@ -64,7 +64,7 @@ class Hash64
     template <typename T>
     inline void operator()(const T &obj)
     {
-        static_assert(std::is_pod<T>::value, "Hash64: POD type required");
+        static_assert(std::is_standard_layout_v<T>, "Hash64: standard layout required");
         (*this)(&obj, sizeof(obj));
     }
 


### PR DESCRIPTION
std::is_pod is deprecated in C++20. The is_trivial requirement for is_pod does not seem to be required here. The important part is the standard layout.