### PR TITLE
tests/unit: Fix build breakage after 3.11.2 merge

### DIFF
--- a/test/unittests/test_capture.cpp
+++ b/test/unittests/test_capture.cpp
@@ -932,17 +932,18 @@ RC_GTEST_PROP(TunBuilderCapture, ExcludesRoute, (const std::string &address, con
     RC_ASSERT(excluded_route.ipv6 == ipv6);
 }
 
-RC_GTEST_PROP(TunBuilderCapture, SetsDNSOptions, (const std::string &address, const unsigned int port, const std::string &search_domain))
+RC_GTEST_PROP(TunBuilderCapture, SetsDNSOptions, (const std::string &search_domain))
 {
     DnsServer server = {};
-    server.addresses.push_back({address, port});
+    auto address = DnsAddress(*rc::genDnsAddressAsStr());
+    server.addresses.push_back(address);
     DnsOptions dns_options = {};
     dns_options.servers[0] = std::move(server);
-    dns_options.search_domains = {{search_domain}};
+    dns_options.search_domains = {DnsDomain(search_domain)};
     const TunBuilderCapture::Ptr tbc(new TunBuilderCapture);
     RC_ASSERT(tbc->tun_builder_set_dns_options(dns_options));
     RC_ASSERT(tbc->dns_options.search_domains.back().domain == search_domain);
-    RC_ASSERT(tbc->dns_options.servers.at(0).addresses.back().address == address);
+    RC_ASSERT(tbc->dns_options.servers.at(0).addresses.back().to_string() == address.to_string());
 }
 
 RC_GTEST_PROP(TunBuilderCapture, SetsLayer, ())
@@ -1040,13 +1041,14 @@ RC_GTEST_PROP(TunBuilderCapture, ResetsTunnelAddresses, (const std::string &addr
     RC_ASSERT(tbc->tunnel_address_index_ipv6 == -1);
 }
 
-RC_GTEST_PROP(TunBuilderCapture, ResetsDNSOptions, (const std::string &address, const unsigned int port, const std::string &search_domain))
+RC_GTEST_PROP(TunBuilderCapture, ResetsDNSOptions, (const std::string &search_domain))
 {
     DnsServer server = {};
-    server.addresses.push_back({address, port});
+    auto address = DnsAddress(*rc::genDnsAddressAsStr());
+    server.addresses.push_back(address);
     DnsOptions dns_options = {};
     dns_options.servers[0] = std::move(server);
-    dns_options.search_domains = {{search_domain}};
+    dns_options.search_domains = {DnsDomain(search_domain)};
     const TunBuilderCapture::Ptr tbc(new TunBuilderCapture);
     RC_ASSERT(tbc->tun_builder_set_dns_options(dns_options));
     RC_ASSERT_FALSE(tbc->dns_options.to_string().empty());

--- a/test/unittests/test_generators.hpp
+++ b/test/unittests/test_generators.hpp
@@ -809,6 +809,35 @@ inline auto genDnsAddress(const bool valid = true) -> Gen<openvpn::DnsAddress>
 }
 
 /**
+    @brief Generates a DNS address as a string.
+    @details This function creates a generator that produces instances of the @c openvpn::DnsAddress class,
+             where the address is represented as a string. The generator can create either valid or invalid
+             DNS addresses based on the provided parameter. It combines an IP address (either IPv4 or IPv6)
+             with an optional port number. The port is randomly included or excluded.
+    @param valid Flag indicating the address should be constrained to valid values.
+    @return Gen<openvpn::DnsAddress> A generator that produces std::string objects with either
+            valid or invalid address values.
+*/
+inline auto genDnsAddressAsStr(const bool valid = true) -> Gen<std::string>
+{
+    return gen::map(
+        gen::tuple(
+            gen::oneOf(IPv4Address(valid), IPv6Address(valid)),
+            gen::maybe(port(valid))),
+        [](const auto &params) -> std::string
+        {
+            const auto &[address, maybe_port] = params;
+            openvpn::DnsAddress result;
+            result.address = address;
+            if (maybe_port)
+            {
+                result.port = *maybe_port;
+            }
+            return result.to_string();
+        });
+}
+
+/**
  * @brief Generates a DNS server.
  * @details Creates a generator that produces random @c openvpn::DnsServer instances with populated fields.
  *          The generator creates:


### PR DESCRIPTION
Use explicit value generation to ensure valid test values are used.