### PR TITLE
Fix inactivity bytes for DCO

### DIFF
--- a/openvpn/log/sessionstats.hpp
+++ b/openvpn/log/sessionstats.hpp
@@ -211,15 +211,14 @@ class SessionStats : public RC<thread_safe_refcount>
                 update_last_packet_received(Time::now());
             }
 
-            // Not using += because volatile compound assignment has been deprecated.
-            stats_[BYTES_IN] = stats_[BYTES_IN] + data.transport_bytes_in;
-            stats_[BYTES_OUT] = stats_[BYTES_OUT] + data.transport_bytes_out;
-            stats_[TUN_BYTES_IN] = stats_[TUN_BYTES_IN] + data.tun_bytes_in;
-            stats_[TUN_BYTES_OUT] = stats_[TUN_BYTES_OUT] + data.tun_bytes_out;
-            stats_[PACKETS_IN] = stats_[PACKETS_IN] + data.transport_pkts_in;
-            stats_[PACKETS_OUT] = stats_[PACKETS_OUT] + data.transport_pkts_out;
-            stats_[TUN_PACKETS_IN] = stats_[TUN_PACKETS_IN] + data.tun_pkts_in;
-            stats_[TUN_PACKETS_OUT] = stats_[TUN_PACKETS_OUT] + data.tun_pkts_out;
+            inc_stat(BYTES_IN, data.transport_bytes_in);
+            inc_stat(BYTES_OUT, data.transport_bytes_out);
+            inc_stat(TUN_BYTES_IN, data.tun_bytes_in);
+            inc_stat(TUN_BYTES_OUT, data.tun_bytes_out);
+            inc_stat(PACKETS_IN, data.transport_pkts_in);
+            inc_stat(PACKETS_OUT, data.transport_pkts_out);
+            inc_stat(TUN_PACKETS_IN, data.tun_pkts_in);
+            inc_stat(TUN_PACKETS_OUT, data.tun_pkts_out);
 
             return true;
         }


### PR DESCRIPTION
When amount of traffic exceeds inactivity bytes
value, the inactivity timer should be reset. Since userspace doesn't see data channel traffic, we have to pull DCO stats from the kernel.

When doing that, we just increment counters
without checking inactivity bytes value. Due to that, we don't reset inactivity timer.

Use inc_stat() method when updating DCO stats, which checks inactivity bytes and resets timer if needed.

Jira: OVPN3-1360