### PR TITLE
Switch to `std::erase_if()`

### DIFF
--- a/openvpn/common/action.hpp
+++ b/openvpn/common/action.hpp
@@ -174,16 +174,14 @@ class ActionList : public std::vector<Action::Ptr>, public DestructorBase
      */
     void remove_marked(const std::unordered_set<std::string> &marks, std::ostream &os)
     {
-        erase(std::remove_if(
-                  begin(), end(), [&](const Action::Ptr &a) mutable
-                  {
+        std::erase_if(*this, [&](const Action::Ptr &a) mutable
+                      {
                                 auto remove = !a->mark.empty() && marks.count(a->mark) > 0;
                                 if (remove)
                                 {
                                     os << "Action '" << a->to_string() << "' will be removed\n";
                                 }
-                                return remove; }),
-              end());
+                                return remove; });
     }
 
   protected:

--- a/openvpn/options/continuation.hpp
+++ b/openvpn/options/continuation.hpp
@@ -213,11 +213,10 @@ class OptionListContinuation : public OptionList
         }
         opts.update_map();
 
-        erase(std::remove_if(begin(), end(), [&opts_to_remove](const Option &o)
-                             {
+        erase_if(*this, [&opts_to_remove](const Option &o)
+                 {
             const std::string &name = o.ref(0);
-            return opts_to_remove.contains(name); }),
-              end());
+            return opts_to_remove.contains(name); });
 
         // we need to remove only original options, not the ones from ongoing PUSH_UPDATE
         // make sure that options are considered for removal only once

--- a/openvpn/ws/resolver_results.hpp
+++ b/openvpn/ws/resolver_results.hpp
@@ -53,12 +53,9 @@ inline void filter_by_ip_version(RESULTS &results, const IP::Addr::Version ip_ve
         return;
     }
 
-    // the "auto" lambda parameter makes this C++14 code
-    data->erase(std::remove_if(data->begin(),
-                               data->end(),
-                               [v4](auto &e)
-                               { return e.endpoint().address().is_v4() != v4; }),
-                data->end());
+    std::erase_if(*data,
+                  [v4](const auto &e)
+                  { return e.endpoint().address().is_v4() != v4; });
 }
 
 #elif defined(ASIO_RESOLVER_RESULTS_DATA_REQUIRED)

--- a/test/unittests/test_continuation.cpp
+++ b/test/unittests/test_continuation.cpp
@@ -149,9 +149,8 @@ static void test_roundtrip(const OptionList &opt_orig, const std::string &prefix
     }
 
     // remove client-side push-continuation directives before comparison
-    cc.erase(std::remove_if(cc.begin(), cc.end(), [](const Option &o)
-                            { return o.size() >= 1 && o.ref(0) == "push-continuation"; }),
-             cc.end());
+    std::erase_if(cc, [](const Option &o)
+                  { return o.size() >= 1 && o.ref(0) == "push-continuation"; });
     require_equal(opt_orig, cc, "TEST_ROUNDTRIP #3");
 
     // defragment back to original form


### PR DESCRIPTION
Since we've moved to C++20, we can now switch from the older, more verbose erase/remove idiom, to the easier-to-parse (and functional equivalent) `std::erase_if()`.