### PR TITLE
ovpncli: Add back std:flush after logging events

### DIFF
--- a/test/ovpncli/cli.cpp
+++ b/test/ovpncli/cli.cpp
@@ -337,6 +337,8 @@ class Client : public ClientBase
         {
             std::cout << "Received event " << ev.name << " " << ev.info << "\n";
         }
+        // We want to log events in near real-time
+        std::cout << std::flush;
     }
 
     void handle_dpc1_protocol(const ClientAPI::AppCustomControlMessageEvent &acev)
@@ -366,6 +368,8 @@ class Client : public ClientBase
         {
             std::cout << "Cannot parse device posture message:" << acev.payload << "\n";
         }
+        // We want to log events in near real-time
+        std::cout << std::flush;
     }
 
     /**
@@ -387,6 +391,8 @@ class Client : public ClientBase
             std::cout << "received unhandled app custom control message for protocol " << acev.protocol
                       << " msg payload: " << acev.payload << "\n";
         }
+        // We want to log events in near real-time
+        std::cout << std::flush;
     }
 
     /**
@@ -422,6 +428,8 @@ class Client : public ClientBase
         {
             start_cert_check_epki("certcheck", clientca_pem);
         }
+        // We want to log events in near real-time
+        std::cout << std::flush;
     }
 
     void open_url(const std::string &url_str)


### PR DESCRIPTION
We want to see them immediately. Partly reverts
commit 6bfb3f5954508f3f2ef206a9e6756cd79f3ab9c4
which replaced std::endl with "\n".