### PR TITLE
common: Include <fmt/format.h> for fmt::format in string.hpp

### DIFF
--- a/openvpn/common/string.hpp
+++ b/openvpn/common/string.hpp
@@ -22,7 +22,7 @@
 #include <algorithm>
 #include <optional>
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 
 #include <openvpn/common/platform.hpp>
 #include <openvpn/common/size.hpp>


### PR DESCRIPTION
string.hpp calls fmt::format and fmt::vformat but only included <fmt/core.h>. As of fmt 12, <fmt/core.h> was reduced to a shim and the format/vformat entry points moved to <fmt/format.h>, so building against a system fmt 12.x fails with "no member named 'format' in namespace 'fmt'" in every translation unit that pulls in string.hpp.

Include <fmt/format.h> instead. It is a superset of the old core.h, so this is backward compatible with older fmt releases while restoring the build on fmt 12.