### PR TITLE
ssl: validate attacker-controlled wkc_len in unwrap_tls_crypt_wkc

### DIFF
--- a/openvpn/ssl/proto.hpp
+++ b/openvpn/ssl/proto.hpp
@@ -2438,17 +2438,38 @@ class ProtoContext : public logging::LoggingMixin<OPENVPN_DEBUG_PROTO,
             std::memcpy(&wkc_len, wkc_raw + wkc_raw_size, sizeof(wkc_len));
             wkc_len = ntohs(wkc_len);
 
+            uint32_t k_id = 0;
+            const size_t serverkey_id_size = proto_config.tls_crypt_v2_serverkey_id ? sizeof(k_id) : 0;
+
             // There's also a payload here, so the assumption that the difference in size
             // from the TLS frame's end to the end of the packet constitutes the WKc no
             // longer holds. We can only rely on wkc_len for P_CONTROL_WKC_V1 packets.
             if (opcode_extract(orig_data[0]) != CONTROL_HARD_RESET_CLIENT_V3)
             {
+                // ``wkc_len`` is read straight from the last two bytes of the received
+                // packet and is therefore fully attacker-controlled. It must be validated
+                // before being used in the pointer arithmetic below: the WKc has to fit
+                // between the end of the tls-crypt frame and the end of the packet, and be
+                // large enough to hold the auth tag, the optional server key ID and the
+                // trailing length field. Without this guard a bogus ``wkc_len`` underflows
+                // the (unsigned) size computations and turns ``wkc_raw`` into a wild
+                // pointer, causing an out-of-bounds read during decryption (an
+                // unauthenticated remote DoS). ``orig_size >= tls_frame_size + hmac_size``
+                // was already established above, so ``orig_size - tls_frame_size`` is safe.
+                if (wkc_len < (sizeof(uint16_t) + hmac_size + serverkey_id_size)
+                    || wkc_len > (orig_size - tls_frame_size))
+                    return Error::CC_ERROR;
+
                 wkc_raw = orig_data + orig_size - wkc_len;
                 wkc_raw_size = wkc_len - sizeof(uint16_t);
             }
 
-            uint32_t k_id = 0;
-            const size_t serverkey_id_size = proto_config.tls_crypt_v2_serverkey_id ? sizeof(k_id) : 0;
+            // For both packet types the WKc must be large enough to hold the auth tag and
+            // the optional server key ID, otherwise the server key ID read below or the
+            // ciphertext length passed to decrypt() (``wkc_raw_size - hmac_size -
+            // serverkey_id_size``) would underflow and read out of bounds.
+            if (wkc_raw_size < (hmac_size + serverkey_id_size))
+                return Error::CC_ERROR;
 
             if (proto_config.tls_crypt_v2_serverkey_id)
             {

--- a/test/unittests/test_proto.cpp
+++ b/test/unittests/test_proto.cpp
@@ -1407,6 +1407,79 @@ TEST_F(ProtoUnitTest, TlsCryptV2ControlPacketCapHonored)
     int ret = test_retry(N_RETRIES, {.tls_crypt_v2_key_fn = "tls-crypt-v2-client-with-serverkey.key", .force_resend_wkc = true, .mssfix_ctrl = 420});
     EXPECT_EQ(ret, 0);
 }
+
+// Security regression test: unwrap_tls_crypt_wkc() reads the 16-bit WKc length
+// (wkc_len) from the last two bytes of the received packet. For CONTROL_WKC_V1
+// packets that value is fully attacker-controlled and, before the bounds-check
+// fix, was fed straight into unsigned pointer arithmetic
+// (wkc_raw = orig_data + orig_size - wkc_len). A wkc_len larger than the packet
+// underflowed the size_t computation into a wild pointer and a bogus/oversized
+// ciphertext length, producing an out-of-bounds read during decryption -- a
+// pre-authentication remote crash (DoS). The unwrap must instead reject the
+// packet with Error::CC_ERROR without dereferencing out of bounds.
+//
+// Builds a minimal ProtoConfig / tls-crypt server context (no full handshake
+// needed) since the malformed length is rejected before any key material is
+// touched.
+class TlsCryptV2WkcUnwrapTest : public testing::Test
+{
+  protected:
+    ProtoContext::ProtoConfig::Ptr pcfg;
+    TLSCryptInstance::Ptr tls_crypt_server;
+
+    void SetUp() override
+    {
+        pcfg.reset(new ProtoContext::ProtoConfig());
+        pcfg->tls_crypt_factory.reset(new CryptoTLSCryptFactory<ClientCryptoAPI>());
+        pcfg->set_tls_crypt_algs();
+        // Fully initialize the server context (single server key, no key ID) so
+        // that a malformed packet which slips past the length validation reaches
+        // the real decrypt() read -- that is the read that goes out of bounds
+        // without the fix (a segfault / ASan SEGV), and which the fix must avoid
+        // by rejecting the packet up front.
+        pcfg->tls_crypt_key.parse(read_text(TEST_KEYCERT_DIR "tls-auth.key"));
+        tls_crypt_server = pcfg->tls_crypt_context->new_obj_recv();
+        tls_crypt_server->init(nullptr,
+                               pcfg->tls_crypt_key.slice(OpenVPNStaticKey::HMAC),
+                               pcfg->tls_crypt_key.slice(OpenVPNStaticKey::CIPHER));
+    }
+
+    // Build a CONTROL_WKC_V1 packet of the given size with the trailing 16-bit
+    // WKc length field set to wkc_len (host order). Contents are otherwise
+    // arbitrary -- the unwrap should bail on the length alone.
+    BufferAllocated make_wkc_v1_packet(size_t size, uint16_t wkc_len)
+    {
+        BufferAllocated buf(size, BufAllocFlags::CONSTRUCT_ZERO);
+        buf.set_size(size);
+        // op byte = op_compose(CONTROL_WKC_V1, key_id=0). CONTROL_WKC_V1 (11)
+        // and op_compose() are protected members of ProtoContext, so encode it
+        // directly here: (opcode << OPCODE_SHIFT[=3]) | key_id. Any opcode other
+        // than CONTROL_HARD_RESET_CLIENT_V3 (10) selects the attacker-controlled
+        // wkc_len branch being exercised.
+        buf.data()[0] = static_cast<unsigned char>(11u << 3);
+        const uint16_t net_wkc_len = htons(wkc_len);
+        std::memcpy(buf.data() + size - sizeof(net_wkc_len), &net_wkc_len, sizeof(net_wkc_len));
+        return buf;
+    }
+};
+
+// wkc_len far larger than the packet: pre-fix this underflowed wkc_raw into a
+// wild pointer read.
+TEST_F(TlsCryptV2WkcUnwrapTest, RejectsWkcLenLargerThanPacket)
+{
+    BufferAllocated buf = make_wkc_v1_packet(200, 60000);
+    EXPECT_EQ(ProtoContext::KeyContext::unwrap_tls_crypt_wkc(buf, *pcfg, *tls_crypt_server),
+              Error::CC_ERROR);
+}
+
+// wkc_len smaller than the auth tag: pre-fix the decrypt ciphertext length
+// (wkc_raw_size - hmac_size) underflowed to a huge oversized read.
+TEST_F(TlsCryptV2WkcUnwrapTest, RejectsWkcLenSmallerThanAuthTag)
+{
+    BufferAllocated buf = make_wkc_v1_packet(200, 4);
+    EXPECT_EQ(ProtoContext::KeyContext::unwrap_tls_crypt_wkc(buf, *pcfg, *tls_crypt_server),
+              Error::CC_ERROR);
+}
 #endif
 
 TEST_F(ProtoUnitTest, BaseMultipleThread)


### PR DESCRIPTION
unwrap_tls_crypt_wkc() reads the 16-bit WKc length from the last two bytes of the received packet. For CONTROL_WKC_V1 packets this value is fully attacker-controlled and was used directly in unsigned pointer arithmetic with no bound against the packet size:

    wkc_raw      = orig_data + orig_size - wkc_len;
    wkc_raw_size = wkc_len - sizeof(uint16_t);

A wkc_len greater than orig_size underflows the size_t computation and turns wkc_raw into a wild pointer roughly (wkc_len - orig_size) bytes before the allocation; the subsequent AEAD decrypt() then reads the "ciphertext" from that pointer, an out-of-bounds read. The existing length sanity check ((wkc_len - 2) != wkc_raw_size) is tautological in this branch because wkc_raw_size was just derived from wkc_len, so it never catches the bad value. WKc packets are processed on the tls-crypt-v2 handshake path before the client is authenticated (control-channel receive and the psid-cookie anti-DoS first-packet path), so any host able to reach the server port can trigger it -- an unauthenticated remote crash (DoS).

Validate wkc_len against the packet before using it: for CONTROL_WKC_V1 the WKc must fit between the end of the tls-crypt frame and the end of the packet and be large enough to hold the auth tag, the optional server key ID and the trailing length field. Additionally guard both packet types so wkc_raw_size covers at least the auth tag and server key ID -- this also closes a second underflow where the decrypt ciphertext length (wkc_raw_size - hmac_size - serverkey_id_size) could wrap for a minimally-sized CONTROL_HARD_RESET_CLIENT_V3 packet. The classic C openvpn is not affected because its equivalent slice uses buf_advance(), which rejects a negative delta.

Add regression tests (TlsCryptV2WkcUnwrapTest) that feed crafted CONTROL_WKC_V1 packets with an oversized and an undersized wkc_len to a fully-initialized tls-crypt server context and assert unwrap returns Error::CC_ERROR instead of reading out of bounds.

Reported-by: Owais Lone (thesecguy) <thesecguy45@gmail.com>